### PR TITLE
Use TypeAdapter for single events validation

### DIFF
--- a/cloudevents_pydantic/formats/json.py
+++ b/cloudevents_pydantic/formats/json.py
@@ -20,14 +20,13 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER         =
 #  DEALINGS IN THE SOFTWARE.                                                   =
 # ==============================================================================
-from typing import List, Type, overload
+from typing import List, TypeVar
 
 from pydantic import TypeAdapter
-from typing_extensions import TypeVar
 
 from ..events import CloudEvent
 
-_T = TypeVar("_T", bound=CloudEvent, default=CloudEvent)
+_T = TypeVar("_T", bound=CloudEvent)
 
 
 def to_json(event: CloudEvent) -> str:
@@ -42,22 +41,20 @@ def to_json(event: CloudEvent) -> str:
     return event.model_dump_json()
 
 
-@overload
-def from_json(data: str) -> CloudEvent: ...
-@overload
-def from_json(data: str, event_class: Type[_T]) -> _T: ...
-def from_json(data: str, event_class: Type[CloudEvent] = CloudEvent) -> CloudEvent:
+def from_json(
+    data: str, event_adapter: TypeAdapter[_T] = TypeAdapter(CloudEvent)
+) -> _T:
     """
     Deserializes an event from JSON format.
 
     :param data: the JSON representation of the event
     :type data: str
-    :param event_class: The event class to build
-    :type event_class: Type[CloudEvent]
+    :param event_adapter: The event class to build
+    :type event_adapter: Type[CloudEvent]
     :return: The deserialized event
     :rtype: CloudEvent
     """
-    return event_class.model_validate_json(data)
+    return event_adapter.validate_json(data)
 
 
 def to_json_batch(

--- a/docs/event_class.md
+++ b/docs/event_class.md
@@ -104,6 +104,7 @@ When you create event types in your app you will want to make sure to follow the
   be kept up to date and make sure their validation, serialization and deserialization rules
   will be compliant with the [CloudEvents spec](https://github.com/cloudevents/spec/tree/main).
 
+/// tab | class Syntax
 ```python
 from typing import TypedDict, Literal
 from cloudevents_pydantic.events import CloudEvent, field_types
@@ -121,6 +122,23 @@ event = OrderCreated.event_factory(
     data={"a_str": "a nice string", "an_int": 1},
 )
 ```
+///
+
+/// tab | inline Syntax
+```python
+from typing import TypedDict, Literal
+from cloudevents_pydantic.events import CloudEvent, field_types
+
+class OrderCreated(CloudEvent):
+    data: TypedDict("OrderCreatedData", {"a_str": field_types.String, "an_int": field_types.Integer})
+    type: Literal["order_created"] = "order_created"
+    source: field_types.String = "order_service"
+
+event = OrderCreated.event_factory(
+    data={"a_str": "a nice string", "an_int": 1},
+)
+```
+///
 
 /// admonition | Use subclasses
     type: warning

--- a/tests/bindings/test_http.py
+++ b/tests/bindings/test_http.py
@@ -21,7 +21,7 @@
 #  DEALINGS IN THE SOFTWARE.                                                   =
 # ==============================================================================
 from typing import List
-from unittest.mock import patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from pydantic import Field, TypeAdapter
@@ -97,16 +97,24 @@ def from_json_batch_spy():
         yield mocked_function
 
 
-def test_initialization_defaults_to_cloudevents(type_adapter_init_mock):
-    handler = HTTPHandler()
-    assert handler.event_class is CloudEvent
-    type_adapter_init_mock.assert_called_once_with(List[CloudEvent])
+def test_initialization_defaults_to_cloudevents(type_adapter_init_mock: MagicMock):
+    HTTPHandler()
+    type_adapter_init_mock.assert_has_calls(
+        [
+            call(CloudEvent),
+            call(List[CloudEvent]),
+        ]
+    )
 
 
-def test_initialization_uses_provided_event_class(type_adapter_init_mock):
-    handler = HTTPHandler(event_class=SomeEvent)
-    assert handler.event_class is SomeEvent
-    type_adapter_init_mock.assert_called_once_with(List[SomeEvent])
+def test_initialization_uses_provided_event_class(type_adapter_init_mock: MagicMock):
+    HTTPHandler(event_class=SomeEvent)
+    type_adapter_init_mock.assert_has_calls(
+        [
+            call(SomeEvent),
+            call(List[SomeEvent]),
+        ]
+    )
 
 
 @pytest.mark.parametrize(
@@ -143,7 +151,7 @@ def test_from_json(from_json_spy):
     handler = HTTPHandler(event_class=SomeEvent)
     event = handler.from_json(valid_json)
 
-    from_json_spy.assert_called_once_with(valid_json, handler.event_class)
+    from_json_spy.assert_called_once_with(valid_json, handler.event_adapter)
     assert event == SomeEvent(**test_attributes)
     assert event != CloudEvent(**test_attributes)
     assert isinstance(event, SomeEvent)

--- a/tests/formats/test_json.py
+++ b/tests/formats/test_json.py
@@ -375,7 +375,7 @@ def test_from_json_base64_with_binary_type(
             batch_adapter=TypeAdapter(Sequence[BinaryDataEvent]),
         )[0]
     else:
-        event = from_json(json_string, BinaryDataEvent)
+        event = from_json(json_string, TypeAdapter(BinaryDataEvent))
     assert event.data == expected_value
     assert isinstance(event, BinaryDataEvent)
 
@@ -412,5 +412,5 @@ def test_nested_binary_fields_correctly_deserialized():
     class BinaryNestedEvent(CloudEvent):
         data: SomeData
 
-    event: BinaryNestedEvent = from_json(json_input, BinaryNestedEvent)
+    event: BinaryNestedEvent = from_json(json_input, TypeAdapter(BinaryNestedEvent))
     assert event.data["data"] == b"\x02\x03\x05\x07"


### PR DESCRIPTION
Use TypeAdapter for single events validation to add support for discriminated unions and improved validation.